### PR TITLE
preload biome assets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.3.0</Version>
+        <Version>0.3.1</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/MakaMek.MapEditor.sln.DotSettings.user
+++ b/MakaMek.MapEditor.sln.DotSettings.user
@@ -3,6 +3,11 @@
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003AClearTerrain_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003FAppData_003FRoaming_003FJetBrains_003FRider2025_002E3_003Fresharper_002Dhost_003FDecompilerCache_003Fdecompiler_003F218caa1b5330430daeee112718c30fa5ce00_003F53_003Fd5297190_003FClearTerrain_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003AEnum_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003FAppData_003FRoaming_003FJetBrains_003FRider2025_002E3_003Fresharper_002Dhost_003FSourcesCache_003F25d8ae608396aeef5ae1a7623dcf2a73d4ac816484f9401137e2883a93466f0_003FEnum_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=7020124F_002D9FFC_002D4AC3_002D8F3D_002DAAB8E0240759_002Ff_003AString_002EManipulation_002Ecs_002Fl_003A_002E_002E_003F_002E_002E_003FAppData_003FRoaming_003FJetBrains_003FRider2025_002E3_003Fresharper_002Dhost_003FSourcesCache_003F99c32020cb38b51da0122b84a8dfd54f5d1bbd6ac327af1dd4da89595c27cd_003FString_002EManipulation_002Ecs/@EntryIndexedValue">ForceIncluded</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=1b7bff79_002Deb2a_002D485a_002D91dc_002Da9feef466b6a/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Constructor_ShouldInitializePreloading" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
+  &lt;TestAncestor&gt;&#xD;
+    &lt;TestId&gt;xUnit::6BD0989A-C39C-B7C7-32CE-2EC3A19F9533::net10.0::MakaMek.MapEditor.Test.ViewModels.MainMenuViewModelTests&lt;/TestId&gt;&#xD;
+  &lt;/TestAncestor&gt;&#xD;
+&lt;/SessionState&gt;</s:String>
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=20588f99_002D5079_002D42e7_002Db1e3_002D784002766d05/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from Solution" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;Solution /&gt;&#xD;
 &lt;/SessionState&gt;</s:String>

--- a/src/MakaMek.MapEditor/DI/ServiceCollectionExtensions.cs
+++ b/src/MakaMek.MapEditor/DI/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
 #endif
             );
         });
+        services.AddSingleton<IFileCachingService, FileSystemCachingService>();
         services.AddSingleton<Map.Factories.IBattleMapFactory, Map.Factories.BattleMapFactory>();
         services.AddSingleton<IImageService>(_ => new AvaloniaAssetImageService("avares://Sanet.MakaMek.MapEditor/Assets"));
         services.AddSingleton<IFileService, AvaloniaFileService>();

--- a/src/MakaMek.MapEditor/DI/ServiceCollectionExtensions.cs
+++ b/src/MakaMek.MapEditor/DI/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Sanet.MakaMek.Assets.Services;
+using Sanet.MakaMek.Core.Services;
+using Sanet.MakaMek.Core.Services.ResourceProviders;
 using Sanet.MakaMek.MapEditor.ViewModels;
 using Sanet.MakaMek.Services;
 using Sanet.MakaMek.Services.Avalonia;
@@ -24,6 +27,21 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<Map.Factories.IBattleMapFactory, Map.Factories.BattleMapFactory>();
         services.AddSingleton<IImageService>(_ => new AvaloniaAssetImageService("avares://Sanet.MakaMek.MapEditor/Assets"));
         services.AddSingleton<IFileService, AvaloniaFileService>();
+        // Register terrain caching service with stream providers
+        services.AddSingleton<ITerrainAssetService>(sp =>
+        {
+            var cachingService = sp.GetRequiredService<IFileCachingService>();
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var streamProviders = new List<IResourceStreamProvider>
+            {
+                new GitHubResourceStreamProvider("mmtx",
+                    "https://api.github.com/repos/anton-makarevich/MakaMek/contents/data/hexes/biomes",
+                    cachingService,
+                    loggerFactory.CreateLogger<GitHubResourceStreamProvider>()
+                )
+            };
+            return new TerrainCachingService(streamProviders, loggerFactory);
+        });
     }
 
     public static void RegisterViewModels(this IServiceCollection services)

--- a/src/MakaMek.MapEditor/MakaMek.MapEditor.csproj
+++ b/src/MakaMek.MapEditor/MakaMek.MapEditor.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <AssemblyName>Sanet.MakaMek.MapEditor</AssemblyName>
     <RootNamespace>Sanet.MakaMek.MapEditor</RootNamespace>
     <Description>Map editor for MakaMek</Description>

--- a/src/MakaMek.MapEditor/ViewModels/MainMenuViewModel.cs
+++ b/src/MakaMek.MapEditor/ViewModels/MainMenuViewModel.cs
@@ -88,7 +88,7 @@ public class MainMenuViewModel : BaseViewModel
             var biomes = await _terrainAssetService.GetLoadedBiomes();
             var biomeCount = biomes.Count();
 
-            _biomeLoadingStatus = biomeCount == 0
+            BiomeLoadingStatus = biomeCount == 0
                 ? "No biomes found"
                 : $"{biomeCount} biomes loaded";
 
@@ -102,14 +102,7 @@ public class MainMenuViewModel : BaseViewModel
         }
         finally
         {
-            UpdateLoadingText();
             IsLoading = false;
         }
-    }
-
-    private void UpdateLoadingText()
-    {
-        // The SetProperty calls in the property setters already handle property notifications
-        // This method can be used for additional UI updates if needed
     }
 }

--- a/src/MakaMek.MapEditor/ViewModels/MainMenuViewModel.cs
+++ b/src/MakaMek.MapEditor/ViewModels/MainMenuViewModel.cs
@@ -18,6 +18,7 @@ public class MainMenuViewModel : BaseViewModel
 
     private string _biomeLoadingStatus = string.Empty;
     private bool _hasError;
+    private bool _isLoading;
 
     public string BiomeLoadingStatus
     {
@@ -29,6 +30,12 @@ public class MainMenuViewModel : BaseViewModel
     {
         get => _hasError;
         private set => SetProperty(ref _hasError, value);
+    }
+
+    public bool IsLoading
+    {
+        get => _isLoading;
+        private set => SetProperty(ref _isLoading, value);
     }
 
     public MainMenuViewModel(IFileService fileService, IBattleMapFactory mapFactory, ILogger<MainMenuViewModel> logger, ITerrainAssetService terrainAssetService)
@@ -76,6 +83,7 @@ public class MainMenuViewModel : BaseViewModel
     {
         try
         {
+            IsLoading = true;
             // Trigger initialization of the terrain caching service
             var biomes = await _terrainAssetService.GetLoadedBiomes();
             var biomeCount = biomes.Count();
@@ -89,12 +97,13 @@ public class MainMenuViewModel : BaseViewModel
         }
         catch (Exception ex)
         {
-            _hasError = true;
-            _biomeLoadingStatus = $"Error loading biomes: {ex.Message}";
+            HasError = true;
+            BiomeLoadingStatus = $"Error loading biomes: {ex.Message}";
         }
         finally
         {
             UpdateLoadingText();
+            IsLoading = false;
         }
     }
 

--- a/src/MakaMek.MapEditor/ViewModels/MainMenuViewModel.cs
+++ b/src/MakaMek.MapEditor/ViewModels/MainMenuViewModel.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using AsyncAwaitBestPractices.MVVM;
 using Microsoft.Extensions.Logging;
+using Sanet.MakaMek.Assets.Services;
 using Sanet.MakaMek.Map.Data;
 using Sanet.MakaMek.Map.Factories;
 using Sanet.MakaMek.Services;
@@ -13,12 +14,32 @@ public class MainMenuViewModel : BaseViewModel
     private readonly IFileService _fileService;
     private readonly IBattleMapFactory _mapFactory;
     private readonly ILogger<MainMenuViewModel> _logger;
+    private readonly ITerrainAssetService _terrainAssetService;
 
-    public MainMenuViewModel(IFileService fileService, IBattleMapFactory mapFactory, ILogger<MainMenuViewModel> logger)
+    private string _biomeLoadingStatus = string.Empty;
+    private bool _hasError;
+
+    public string BiomeLoadingStatus
+    {
+        get => _biomeLoadingStatus;
+        private set => SetProperty(ref _biomeLoadingStatus, value);
+    }
+
+    public bool HasError
+    {
+        get => _hasError;
+        private set => SetProperty(ref _hasError, value);
+    }
+
+    public MainMenuViewModel(IFileService fileService, IBattleMapFactory mapFactory, ILogger<MainMenuViewModel> logger, ITerrainAssetService terrainAssetService)
     {
         _fileService = fileService;
         _mapFactory = mapFactory;
         _logger = logger;
+        _terrainAssetService = terrainAssetService;
+        
+        // Initialize preloading
+        _ = PreloadBiomes();
     }
 
     public IAsyncCommand CreateNewMapCommand => field ??= new AsyncCommand(() => 
@@ -47,4 +68,39 @@ public class MainMenuViewModel : BaseViewModel
             _logger.LogError(ex, "Failed to load map");
         }
     });
+
+    /// <summary>
+    /// Preloads biome data from all configured providers
+    /// </summary>
+    private async Task PreloadBiomes()
+    {
+        try
+        {
+            // Trigger initialization of the terrain caching service
+            var biomes = await _terrainAssetService.GetLoadedBiomes();
+            var biomeCount = biomes.Count();
+
+            _biomeLoadingStatus = biomeCount == 0
+                ? "No biomes found"
+                : $"{biomeCount} biomes loaded";
+
+            if (biomeCount == 0)
+                throw new Exception("No biomes found");
+        }
+        catch (Exception ex)
+        {
+            _hasError = true;
+            _biomeLoadingStatus = $"Error loading biomes: {ex.Message}";
+        }
+        finally
+        {
+            UpdateLoadingText();
+        }
+    }
+
+    private void UpdateLoadingText()
+    {
+        // The SetProperty calls in the property setters already handle property notifications
+        // This method can be used for additional UI updates if needed
+    }
 }

--- a/src/MakaMek.MapEditor/ViewModels/MainMenuViewModel.cs
+++ b/src/MakaMek.MapEditor/ViewModels/MainMenuViewModel.cs
@@ -29,14 +29,24 @@ public class MainMenuViewModel : BaseViewModel
     public bool HasError
     {
         get => _hasError;
-        private set => SetProperty(ref _hasError, value);
+        private set
+        {
+            SetProperty(ref _hasError, value);
+            NotifyPropertyChanged(nameof(CanShowMenu));
+        }
     }
 
     public bool IsLoading
     {
         get => _isLoading;
-        private set => SetProperty(ref _isLoading, value);
+        private set
+        {
+            SetProperty(ref _isLoading, value);
+            NotifyPropertyChanged(nameof(CanShowMenu));
+        }
     }
+
+    public bool CanShowMenu => !IsLoading && !HasError;
 
     public MainMenuViewModel(IFileService fileService, IBattleMapFactory mapFactory, ILogger<MainMenuViewModel> logger, ITerrainAssetService terrainAssetService)
     {

--- a/src/MakaMek.MapEditor/Views/MainMenuView.axaml
+++ b/src/MakaMek.MapEditor/Views/MainMenuView.axaml
@@ -7,10 +7,23 @@
              x:Class="Sanet.MakaMek.MapEditor.Views.MainMenuView"
              x:DataType="viewModels:MainMenuViewModel">
     <Grid RowDefinitions="*,Auto,Auto,*" ColumnDefinitions="*,Auto,*">
-        <StackPanel Grid.Row="1" Grid.Column="1" Spacing="20">
+        <StackPanel Grid.Row="1" Grid.Column="1" Spacing="20" IsVisible="{Binding !IsLoading}">
             <TextBlock Text="MakaMek Map Editor" FontSize="30" HorizontalAlignment="Center" FontWeight="Bold"/>
             <Button Content="Create New Map" Command="{Binding CreateNewMapCommand}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" FontSize="20"/>
             <Button Content="Load Map" Command="{Binding LoadMapCommand}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" FontSize="20"/>
+        </StackPanel>
+        
+        <!-- Loading Section -->
+        <StackPanel Grid.Row="1" Grid.Column="1" Spacing="10" IsVisible="{Binding IsLoading}">
+            <TextBlock Text="Loading terrain data..." FontSize="16" HorizontalAlignment="Center"/>
+            <ProgressBar IsIndeterminate="True" Height="20" Width="200"/>
+            <TextBlock Text="{Binding BiomeLoadingStatus}" FontSize="14" HorizontalAlignment="Center" Foreground="Gray"/>
+        </StackPanel>
+            
+        <!-- Error Section -->
+        <StackPanel Grid.Row="1" Grid.Column="1" Spacing="10" IsVisible="{Binding HasError}">
+            <TextBlock Text="Error loading terrain data" FontSize="16" HorizontalAlignment="Center" Foreground="Red"/>
+            <TextBlock Text="{Binding BiomeLoadingStatus}" FontSize="14" HorizontalAlignment="Center" Foreground="Red" TextWrapping="Wrap"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/MakaMek.MapEditor/Views/MainMenuView.axaml
+++ b/src/MakaMek.MapEditor/Views/MainMenuView.axaml
@@ -7,7 +7,7 @@
              x:Class="Sanet.MakaMek.MapEditor.Views.MainMenuView"
              x:DataType="viewModels:MainMenuViewModel">
     <Grid RowDefinitions="*,Auto,Auto,*" ColumnDefinitions="*,Auto,*">
-        <StackPanel Grid.Row="1" Grid.Column="1" Spacing="20" IsVisible="{Binding !IsLoading}">
+        <StackPanel Grid.Row="1" Grid.Column="1" Spacing="20" IsVisible="{Binding CanShowMenu}">
             <TextBlock Text="MakaMek Map Editor" FontSize="30" HorizontalAlignment="Center" FontWeight="Bold"/>
             <Button Content="Create New Map" Command="{Binding CreateNewMapCommand}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" FontSize="20"/>
             <Button Content="Load Map" Command="{Binding LoadMapCommand}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" FontSize="20"/>

--- a/tests/MakaMek.MapEditor.Test/ViewModels/MainMenuViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/MainMenuViewModelTests.cs
@@ -258,6 +258,7 @@ public class MainMenuViewModelTests
         // Assert
         Assert.Contains("2 biomes loaded", viewModel.BiomeLoadingStatus);
         Assert.False(viewModel.HasError);
+        Assert.False(viewModel.IsLoading);
     }
 
     [Fact]
@@ -276,6 +277,7 @@ public class MainMenuViewModelTests
         // Assert
         Assert.Contains("No biomes found", viewModel.BiomeLoadingStatus);
         Assert.True(viewModel.HasError);
+        Assert.False(viewModel.IsLoading);
     }
 
     [Fact]
@@ -293,5 +295,6 @@ public class MainMenuViewModelTests
         // Assert
         Assert.Contains("Error loading biomes: Service unavailable", viewModel.BiomeLoadingStatus);
         Assert.True(viewModel.HasError);
+        Assert.False(viewModel.IsLoading);
     }
 }

--- a/tests/MakaMek.MapEditor.Test/ViewModels/MainMenuViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/MainMenuViewModelTests.cs
@@ -9,6 +9,7 @@ using Sanet.MakaMek.Map.Models.Terrains;
 using Sanet.MakaMek.MapEditor.ViewModels;
 using Sanet.MakaMek.Services;
 using Sanet.MVVM.Core.Services;
+using Shouldly;
 using Xunit;
 
 namespace MakaMek.MapEditor.Test.ViewModels;
@@ -256,9 +257,9 @@ public class MainMenuViewModelTests
         await Task.Delay(100);
         
         // Assert
-        Assert.Contains("2 biomes loaded", viewModel.BiomeLoadingStatus);
-        Assert.False(viewModel.HasError);
-        Assert.False(viewModel.IsLoading);
+        viewModel.BiomeLoadingStatus.ShouldContain("2 biomes loaded");
+        viewModel.HasError.ShouldBeFalse();
+        viewModel.IsLoading.ShouldBeFalse();
     }
 
     [Fact]
@@ -275,9 +276,9 @@ public class MainMenuViewModelTests
         await Task.Delay(100);
         
         // Assert
-        Assert.Contains("No biomes found", viewModel.BiomeLoadingStatus);
-        Assert.True(viewModel.HasError);
-        Assert.False(viewModel.IsLoading);
+        viewModel.BiomeLoadingStatus.ShouldContain("No biomes found");
+        viewModel.HasError.ShouldBeTrue();
+        viewModel.IsLoading.ShouldBeFalse();
     }
 
     [Fact]
@@ -293,8 +294,8 @@ public class MainMenuViewModelTests
         await Task.Delay(100);
         
         // Assert
-        Assert.Contains("Error loading biomes: Service unavailable", viewModel.BiomeLoadingStatus);
-        Assert.True(viewModel.HasError);
-        Assert.False(viewModel.IsLoading);
+        viewModel.BiomeLoadingStatus.ShouldContain("Error loading biomes: Service unavailable");
+        viewModel.HasError.ShouldBeTrue();
+        viewModel.IsLoading.ShouldBeFalse();
     }
 }

--- a/tests/MakaMek.MapEditor.Test/ViewModels/MainMenuViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/MainMenuViewModelTests.cs
@@ -25,7 +25,7 @@ public class MainMenuViewModelTests
 
     public MainMenuViewModelTests()
     {
-        _sut = new MainMenuViewModel(_fileService, _mapFactory, _mainMenuLogger);
+        _sut = new MainMenuViewModel(_fileService, _mapFactory, _mainMenuLogger, _assetService);
         _sut.SetNavigationService(_navigationService);
     }
 
@@ -233,5 +233,65 @@ public class MainMenuViewModelTests
         await _sut.LoadMapCommand.ExecuteAsync();
 
         await _navigationService.DidNotReceive().NavigateToViewModelAsync(Arg.Any<EditMapViewModel>());
+    }
+
+    [Fact]
+    public void Constructor_ShouldInitializePreloading()
+    {
+        // Assert
+        _assetService.Received(1).GetLoadedBiomes();
+    }
+
+    [Fact]
+    public async Task PreloadBiomes_WhenBiomesExist_ShouldSetSuccessStatus()
+    {
+        // Arrange
+        var biomes = new[] { "biome1", "biome2" };
+        _assetService.GetLoadedBiomes().Returns(biomes);
+        
+        // Create a new instance to trigger preloading
+        var viewModel = new MainMenuViewModel(_fileService, _mapFactory, _mainMenuLogger, _assetService);
+        
+        // Wait for the async operation to complete
+        await Task.Delay(100);
+        
+        // Assert
+        Assert.Contains("2 biomes loaded", viewModel.BiomeLoadingStatus);
+        Assert.False(viewModel.HasError);
+    }
+
+    [Fact]
+    public async Task PreloadBiomes_WhenNoBiomesExist_ShouldSetErrorStatus()
+    {
+        // Arrange
+        var biomes = Array.Empty<string>();
+        _assetService.GetLoadedBiomes().Returns(biomes);
+        
+        // Create a new instance to trigger preloading
+        var viewModel = new MainMenuViewModel(_fileService, _mapFactory, _mainMenuLogger, _assetService);
+        
+        // Wait for the async operation to complete
+        await Task.Delay(100);
+        
+        // Assert
+        Assert.Contains("No biomes found", viewModel.BiomeLoadingStatus);
+        Assert.True(viewModel.HasError);
+    }
+
+    [Fact]
+    public async Task PreloadBiomes_WhenExceptionOccurs_ShouldSetErrorStatus()
+    {
+        // Arrange
+        _assetService.GetLoadedBiomes().Returns(Task.FromException<IEnumerable<string>>(new InvalidOperationException("Service unavailable")));
+        
+        // Create a new instance to trigger preloading
+        var viewModel = new MainMenuViewModel(_fileService, _mapFactory, _mainMenuLogger, _assetService);
+        
+        // Wait for the async operation to complete
+        await Task.Delay(100);
+        
+        // Assert
+        Assert.Contains("Error loading biomes: Service unavailable", viewModel.BiomeLoadingStatus);
+        Assert.True(viewModel.HasError);
     }
 }

--- a/tests/MakaMek.MapEditor.Test/ViewModels/MainMenuViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/MainMenuViewModelTests.cs
@@ -260,6 +260,7 @@ public class MainMenuViewModelTests
         viewModel.BiomeLoadingStatus.ShouldContain("2 biomes loaded");
         viewModel.HasError.ShouldBeFalse();
         viewModel.IsLoading.ShouldBeFalse();
+        viewModel.CanShowMenu.ShouldBeTrue();
     }
 
     [Fact]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Main menu now preloads terrain biomes on startup and shows a loading view with progress and status text, plus an error view if preload fails.

* **Chores**
  * Added terrain asset caching support and enabled compiled bindings by default to improve startup/load behavior.

* **Tests**
  * Added unit tests covering biome preloading: success, empty results, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->