### PR TITLE
Feat/30 map configuration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.5.4</Version>
+        <Version>0.5.5</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.MapEditor/ViewModels/EditMapViewModel.cs
+++ b/src/MakaMek.MapEditor/ViewModels/EditMapViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Reactive.Concurrency;
 using System.Text.Json;
 using AsyncAwaitBestPractices.MVVM;
@@ -9,6 +10,7 @@ using Sanet.MakaMek.Map.Models;
 using Sanet.MakaMek.Map.Models.Terrains;
 using Sanet.MakaMek.Map.Services;
 using Sanet.MakaMek.MapEditor.Models;
+using Sanet.MakaMek.MapEditor.ViewModels.Wrappers;
 using Sanet.MakaMek.Services;
 using Sanet.MVVM.Core.ViewModels;
 
@@ -29,6 +31,10 @@ public class EditMapViewModel : BaseViewModel
     
     public IScheduler? Scheduler { get; }
 
+    private readonly PropertyChangedEventHandler? _hexConfigurationChangedHandler;
+
+    public HexRenderConfigurationViewModel HexConfiguration { get; }
+
     public EditMapViewModel(IFileService fileService,
         ITerrainAssetService assetService,
         ILocalizationService localizationService,
@@ -42,8 +48,17 @@ public class EditMapViewModel : BaseViewModel
         Logger = logger;
         TerrainBitmaskService = terrainBitmaskService;
         Scheduler = scheduler;
+        HexConfiguration = new HexRenderConfigurationViewModel();
+        _hexConfigurationChangedHandler = (_, _) => NotifyPropertyChanged(nameof(HexConfiguration));
+        HexConfiguration.PropertyChanged += _hexConfigurationChangedHandler;
     }
-    
+
+    public override void DetachHandlers()
+    {
+        base.DetachHandlers();
+        HexConfiguration.PropertyChanged -= _hexConfigurationChangedHandler;
+    }
+
     public ILogger<EditMapViewModel> Logger { get; }
 
     public ObservableCollection<Terrain> AvailableTerrains { get; } = [];

--- a/src/MakaMek.MapEditor/ViewModels/Wrappers/HexRenderConfigurationViewModel.cs
+++ b/src/MakaMek.MapEditor/ViewModels/Wrappers/HexRenderConfigurationViewModel.cs
@@ -1,0 +1,24 @@
+using Sanet.MakaMek.Map.Data;
+using Sanet.MVVM.Core.ViewModels;
+
+namespace Sanet.MakaMek.MapEditor.ViewModels.Wrappers;
+
+public class HexRenderConfigurationViewModel : BindableBase
+{
+    public bool ShowLabels
+    {
+        get;
+        set => SetProperty(ref field, value);
+    } = true;
+
+    public bool ShowOutline
+    {
+        get;
+        set => SetProperty(ref field, value);
+    } = true;
+
+    public HexRenderConfiguration ToConfiguration()
+    {
+        return new HexRenderConfiguration(ShowLabels, ShowOutline, false);
+    }
+}

--- a/src/MakaMek.MapEditor/Views/EditMapView.axaml
+++ b/src/MakaMek.MapEditor/Views/EditMapView.axaml
@@ -20,7 +20,7 @@
             ContentClicked="MapCanvas_OnContentClicked"
             x:Name="MapCanvas"/>
         
-        <Grid Grid.Column="1" RowDefinitions="Auto,*,Auto" Background="#333333">
+        <Grid Grid.Column="1" RowDefinitions="Auto,*,Auto,Auto" Background="#333333">
             <TextBlock Text="{extensions:Localize 'EditMap_Toolbox'}" FontSize="18" FontWeight="Bold" Margin="10" Foreground="White" HorizontalAlignment="Center"/>
 
             <ListBox Grid.Row="1" ItemsSource="{Binding AvailableTools}" SelectedItem="{Binding SelectedTool}" Background="Transparent">
@@ -33,7 +33,17 @@
                 </ListBox.ItemTemplate>
             </ListBox>
             
-            <Button Grid.Row="2" Content="{extensions:Localize 'EditMap_ExportMap'}" Command="{Binding ExportMapCommand}" HorizontalAlignment="Stretch" Margin="10" VerticalAlignment="Bottom"/>
+            <StackPanel Grid.Row="2" Margin="10" Spacing="10">
+                <TextBlock Text="{extensions:Localize 'BattleMap_Settings'}" FontSize="16" FontWeight="Bold" Foreground="White"/>
+                <CheckBox Content="{extensions:Localize 'BattleMap_ShowLabels'}"
+                          IsChecked="{Binding HexConfiguration.ShowLabels}"
+                          Foreground="White"/>
+                <CheckBox Content="{extensions:Localize 'BattleMap_ShowHexOutlines'}"
+                          IsChecked="{Binding HexConfiguration.ShowOutline}"
+                          Foreground="White"/>
+            </StackPanel>
+
+            <Button Grid.Row="3" Content="{extensions:Localize 'EditMap_ExportMap'}" Command="{Binding ExportMapCommand}" HorizontalAlignment="Stretch" Margin="10" VerticalAlignment="Bottom"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/MakaMek.MapEditor/Views/EditMapView.axaml.cs
+++ b/src/MakaMek.MapEditor/Views/EditMapView.axaml.cs
@@ -33,6 +33,17 @@ public partial class EditMapView : BaseView<EditMapViewModel>
         {
             RenderMap();
         }
+        else if (e.PropertyName == nameof(EditMapViewModel.HexConfiguration))
+        {
+            if (ViewModel?.HexConfiguration != null)
+            {
+                var config = ViewModel.HexConfiguration.ToConfiguration();
+                foreach (var hexControl in MapCanvas.Children.OfType<HexControl>())
+                {
+                    hexControl.UpdateRenderConfiguration(config);
+                }
+            }
+        }
     }
 
     private CanonicalBitmaskResult? ComputeWaterBitmask(Hex hex)
@@ -54,7 +65,7 @@ public partial class EditMapView : BaseView<EditMapViewModel>
             ViewModel.Logger,
             ViewModel.AssetService,
             ViewModel.LocalizationService,
-            edges, null, waterBitmask, ViewModel.Scheduler);
+            edges, ViewModel.HexConfiguration?.ToConfiguration(), waterBitmask, ViewModel.Scheduler);
 
         if (_hexControlsByCoords.TryGetValue(coords, out var oldControl))
             MapCanvas.Children.Remove(oldControl);

--- a/tests/MakaMek.MapEditor.Test/ViewModels/EditMapViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/EditMapViewModelTests.cs
@@ -1116,4 +1116,50 @@ public class EditMapViewModelTests
         waterTerrain.ShouldNotBeNull();
         waterTerrain.Height.ShouldBe(0); // should not become positive
     }
+    [Fact]
+    public void HexConfiguration_ShouldBeInitializedViaConstructor()
+    {
+        _sut.HexConfiguration.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HexConfiguration_WhenPropertyChanged_ShouldRaiseViewModelPropertyChanged()
+    {
+        // Arrange
+        var propertyChangedRaised = false;
+        _sut.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(EditMapViewModel.HexConfiguration))
+            {
+                propertyChangedRaised = true;
+            }
+        };
+
+        // Act
+        _sut.HexConfiguration.ShowLabels = !_sut.HexConfiguration.ShowLabels;
+
+        // Assert
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DetachHandlers_ShouldUnsubscribeFromHexConfigurationPropertyChanged()
+    {
+        // Arrange
+        var propertyChangedRaised = false;
+        _sut.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(EditMapViewModel.HexConfiguration))
+            {
+                propertyChangedRaised = true;
+            }
+        };
+        _sut.DetachHandlers();
+
+        // Act
+        _sut.HexConfiguration.ShowLabels = !_sut.HexConfiguration.ShowLabels;
+
+        // Assert
+        propertyChangedRaised.ShouldBeFalse();
+    }
 }

--- a/tests/MakaMek.MapEditor.Test/ViewModels/Wrappers/HexRenderConfigurationViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/Wrappers/HexRenderConfigurationViewModelTests.cs
@@ -1,0 +1,94 @@
+using Sanet.MakaMek.MapEditor.ViewModels.Wrappers;
+using Shouldly;
+using Xunit;
+
+namespace MakaMek.MapEditor.Test.ViewModels.Wrappers;
+
+public class HexRenderConfigurationViewModelTests
+{
+    private readonly HexRenderConfigurationViewModel _sut = new();
+
+    [Fact]
+    public void ShowLabels_DefaultValue_ShouldBeTrue()
+    {
+        _sut.ShowLabels.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShowOutline_DefaultValue_ShouldBeTrue()
+    {
+        _sut.ShowOutline.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ToConfiguration_ShouldMapPropertiesCorrectly()
+    {
+        // Arrange
+        _sut.ShowLabels = false;
+        _sut.ShowOutline = false;
+
+        // Act
+        var config = _sut.ToConfiguration();
+
+        // Assert
+        config.ShowLabels.ShouldBeFalse();
+        config.ShowOutline.ShouldBeFalse();
+        config.ShowHighlightLabels.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ToConfiguration_WithTrueValues_ShouldMapPropertiesCorrectly()
+    {
+        // Arrange
+        _sut.ShowLabels = true;
+        _sut.ShowOutline = true;
+
+        // Act
+        var config = _sut.ToConfiguration();
+
+        // Assert
+        config.ShowLabels.ShouldBeTrue();
+        config.ShowOutline.ShouldBeTrue();
+        config.ShowHighlightLabels.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ShowLabels_WhenChanged_ShouldRaisePropertyChanged()
+    {
+        // Arrange
+        var propertyChangedRaised = false;
+        _sut.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(HexRenderConfigurationViewModel.ShowLabels))
+            {
+                propertyChangedRaised = true;
+            }
+        };
+
+        // Act
+        _sut.ShowLabels = false;
+
+        // Assert
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShowOutline_WhenChanged_ShouldRaisePropertyChanged()
+    {
+        // Arrange
+        var propertyChangedRaised = false;
+        _sut.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(HexRenderConfigurationViewModel.ShowOutline))
+            {
+                propertyChangedRaised = true;
+            }
+        };
+
+        // Act
+        _sut.ShowOutline = false;
+
+        // Assert
+        propertyChangedRaised.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.5.5

* **New Features**
  * Added hex rendering configuration controls to the map editor. Users can now toggle the visibility of individual hex labels and hexagon outlines directly from the toolbox, with changes reflected immediately on the map canvas.

* **Tests**
  * Added comprehensive unit test coverage for the hex configuration functionality.

* **Chores**
  * Version bump to 0.5.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anton-makarevich/MakaMek.MapEditor/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->