### PR TITLE
feat: close hex info popup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.6.3</Version>
+        <Version>0.6.4</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.MapEditor/Services/MapEditorFakeLocalizationService.cs
+++ b/src/MakaMek.MapEditor/Services/MapEditorFakeLocalizationService.cs
@@ -39,6 +39,7 @@ public class MapEditorFakeLocalizationService : FakeLocalizationService
         _strings["EditMap_Terrains"] = "Terrains:";
         _strings["EditMap_WaterDepth"] = "Water Depth:";
         _strings["EditMap_Settings"] = "☰ Settings";
+        _strings["EditMap_CloseHexInfo"] = "Close";
 
         _strings["Window_Title"] = "MakaMek Map Editor";
     }

--- a/src/MakaMek.MapEditor/ViewModels/EditMapViewModel.cs
+++ b/src/MakaMek.MapEditor/ViewModels/EditMapViewModel.cs
@@ -364,4 +364,11 @@ public class EditMapViewModel : BaseViewModel
         IsSettingsPanelVisible = !IsSettingsPanelVisible;
         return Task.CompletedTask;
     });
+
+    public IAsyncCommand CloseHexInfoCommand => field ??= new AsyncCommand(() =>
+    {
+        IsHexInfoVisible = false;
+        HexViewModel = null;
+        return Task.CompletedTask;
+    });
 }

--- a/src/MakaMek.MapEditor/ViewModels/Wrappers/HexViewModel.cs
+++ b/src/MakaMek.MapEditor/ViewModels/Wrappers/HexViewModel.cs
@@ -11,6 +11,7 @@ public class HexViewModel : BindableBase
     }
 
     public int Level { get; private set; }
+    public string Coordinates { get; private set; } = string.Empty;
     public IReadOnlyList<string> TerrainTypes { get; private set; } = [];
     public int? WaterDepth { get; private set; }
     public bool IsWater => WaterDepth.HasValue;
@@ -18,9 +19,11 @@ public class HexViewModel : BindableBase
     public void UpdateFromHex(Hex hex)
     {
         Level = hex.Level;
+        Coordinates = hex.Coordinates.ToString();
         TerrainTypes = hex.GetTerrains().Select(t => t.Id.ToString()).ToList();
         WaterDepth = hex.GetWaterDepth();
         NotifyPropertyChanged(nameof(Level));
+        NotifyPropertyChanged(nameof(Coordinates));
         NotifyPropertyChanged(nameof(TerrainTypes));
         NotifyPropertyChanged(nameof(WaterDepth));
         NotifyPropertyChanged(nameof(IsWater));

--- a/src/MakaMek.MapEditor/Views/EditMapView.axaml
+++ b/src/MakaMek.MapEditor/Views/EditMapView.axaml
@@ -32,6 +32,15 @@
                 Padding="10" CornerRadius="4" MinWidth="150"
                 HorizontalAlignment="Left" VerticalAlignment="Top" ZIndex="100">
             <StackPanel Spacing="4">
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock Text="{Binding HexViewModel.Coordinates}"
+                               Foreground="White" FontWeight="Bold"/>
+                    <Button Grid.Column="1" Content="✕"
+                            Command="{Binding CloseHexInfoCommand}"
+                            ToolTip.Tip="{extensions:Localize 'EditMap_CloseHexInfo'}"
+                            Background="Transparent" Foreground="White"
+                            BorderThickness="0" FontSize="14" Cursor="Hand"/>
+                </Grid>
                 <TextBlock Text="{extensions:Localize 'EditMap_Elevation'}"
                            Foreground="White" FontWeight="Bold"/>
                 <TextBlock Text="{Binding HexViewModel.Level}"

--- a/tests/MakaMek.MapEditor.Test/Services/MapEditorFakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.MapEditor.Test/Services/MapEditorFakeLocalizationServiceTests.cs
@@ -63,6 +63,7 @@ public class MapEditorFakeLocalizationServiceTests
     [InlineData("EditMap_ExportPdfDialogTitle", "Export Map as PDF")]
     [InlineData("EditMap_PdfFilesFilter", "PDF Files")]
     [InlineData("EditMap_Settings", "☰ Settings")]
+    [InlineData("EditMap_CloseHexInfo", "Close")]
     [InlineData("EditMap_Elevation", "Elevation:")]
     [InlineData("EditMap_Terrains", "Terrains:")]
     [InlineData("EditMap_WaterDepth", "Water Depth:")]

--- a/tests/MakaMek.MapEditor.Test/ViewModels/EditMapViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/EditMapViewModelTests.cs
@@ -1457,6 +1457,27 @@ public class EditMapViewModelTests
         _sut.IsHexInfoVisible.ShouldBeTrue();
     }
 
+    // --- CloseHexInfoCommand tests ---
+
+    [Fact]
+    public async Task CloseHexInfoCommand_ShouldHideHexInfoAndClearViewModel()
+    {
+        // Arrange - set up cursor mode with hex info visible
+        var hex = new Hex(new HexCoordinates(0, 0));
+        hex.AddTerrain(new ClearTerrain());
+        _sut.SelectedTool = new ToolItem("Cursor", ToolType.Cursor);
+        _sut.HandleHexSelection(hex);
+        _sut.HexViewModel.ShouldNotBeNull();
+        _sut.IsHexInfoVisible.ShouldBeTrue();
+
+        // Act
+        await _sut.CloseHexInfoCommand.ExecuteAsync();
+
+        // Assert
+        _sut.IsHexInfoVisible.ShouldBeFalse();
+        _sut.HexViewModel.ShouldBeNull();
+    }
+
     // --- Tool-missing fallback tests (AvailableTools populated but tool absent) ---
     [Fact]
     public async Task RaiseLevelCommand_WhenToolsPopulatedButRaiseLevelMissing_ShouldSetActiveEditMode()

--- a/tests/MakaMek.MapEditor.Test/ViewModels/Wrappers/HexViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/Wrappers/HexViewModelTests.cs
@@ -19,6 +19,18 @@ public class HexViewModelTests
     }
 
     [Fact]
+    public void Constructor_ShouldReadCoordinates()
+    {
+        var hex = new Hex(new HexCoordinates(3, 7));
+
+        var sut = new HexViewModel(hex);
+
+        sut.Coordinates.ShouldNotBeNullOrEmpty();
+        sut.Coordinates.ShouldContain("3");
+        sut.Coordinates.ShouldContain("7");
+    }
+
+    [Fact]
     public void Constructor_ShouldReadTerrainTypes()
     {
         var hex = new Hex(new HexCoordinates(0, 0));
@@ -86,12 +98,14 @@ public class HexViewModelTests
         hex.AddTerrain(new ClearTerrain());
         var sut = new HexViewModel(hex);
 
-        var updatedHex = new Hex(new HexCoordinates(0, 0), level: 3);
+        var updatedHex = new Hex(new HexCoordinates(5, 9), level: 3);
         updatedHex.AddTerrain(new WaterTerrain(-1));
 
         sut.UpdateFromHex(updatedHex);
 
         sut.Level.ShouldBe(3);
+        sut.Coordinates.ShouldContain("5");
+        sut.Coordinates.ShouldContain("9");
         sut.TerrainTypes.ShouldContain("Water");
         sut.WaterDepth.ShouldBe(1);
         sut.IsWater.ShouldBeTrue();
@@ -122,6 +136,7 @@ public class HexViewModelTests
         var sut = new HexViewModel(hex);
 
         var levelChanged = false;
+        var coordinatesChanged = false;
         var terrainChanged = false;
         var waterDepthChanged = false;
         var isWaterChanged = false;
@@ -130,17 +145,19 @@ public class HexViewModelTests
             switch (args.PropertyName)
             {
                 case nameof(HexViewModel.Level): levelChanged = true; break;
+                case nameof(HexViewModel.Coordinates): coordinatesChanged = true; break;
                 case nameof(HexViewModel.TerrainTypes): terrainChanged = true; break;
                 case nameof(HexViewModel.WaterDepth): waterDepthChanged = true; break;
                 case nameof(HexViewModel.IsWater): isWaterChanged = true; break;
             }
         };
 
-        var updatedHex = new Hex(new HexCoordinates(0, 0), level: 7);
+        var updatedHex = new Hex(new HexCoordinates(1, 2), level: 7);
         updatedHex.AddTerrain(new WaterTerrain(-3));
         sut.UpdateFromHex(updatedHex);
 
         levelChanged.ShouldBeTrue();
+        coordinatesChanged.ShouldBeTrue();
         terrainChanged.ShouldBeTrue();
         waterDepthChanged.ShouldBeTrue();
         isWaterChanged.ShouldBeTrue();

--- a/tests/MakaMek.MapEditor.Test/ViewModels/Wrappers/HexViewModelTests.cs
+++ b/tests/MakaMek.MapEditor.Test/ViewModels/Wrappers/HexViewModelTests.cs
@@ -25,9 +25,7 @@ public class HexViewModelTests
 
         var sut = new HexViewModel(hex);
 
-        sut.Coordinates.ShouldNotBeNullOrEmpty();
-        sut.Coordinates.ShouldContain("3");
-        sut.Coordinates.ShouldContain("7");
+        sut.Coordinates.ShouldBe(hex.Coordinates.ToString());
     }
 
     [Fact]
@@ -104,8 +102,7 @@ public class HexViewModelTests
         sut.UpdateFromHex(updatedHex);
 
         sut.Level.ShouldBe(3);
-        sut.Coordinates.ShouldContain("5");
-        sut.Coordinates.ShouldContain("9");
+        sut.Coordinates.ShouldBe(updatedHex.Coordinates.ToString());
         sut.TerrainTypes.ShouldContain("Water");
         sut.WaterDepth.ShouldBe(1);
         sut.IsWater.ShouldBeTrue();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The map editor now shows hex coordinates in the hex information panel.
  * Added a close button to dismiss the hex info panel.

* **Bug Fixes**
  * Closing the hex info panel now clears the selected hex details consistently.

* **Chores**
  * Updated the app/package version to 0.6.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->